### PR TITLE
fix: use global config

### DIFF
--- a/apple/HelloWorld/AppDelegate.swift
+++ b/apple/HelloWorld/AppDelegate.swift
@@ -5,7 +5,14 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
   var window: UIWindow?
 
   func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?) -> Bool {
-    LynxEnv.sharedInstance()
+    let lynxEnv = LynxEnv.sharedInstance()
+    let config = LynxConfig(provider: TemplateProvider())
+    
+    // Register new modules with:
+    // config.register(YourModuleName.self)
+    
+    lynxEnv.prepareConfig(config)
+    
     return true
   }
 }

--- a/apple/HelloWorld/HelloWorld-Bridging-Header.h
+++ b/apple/HelloWorld/HelloWorld-Bridging-Header.h
@@ -3,3 +3,4 @@
 #import <Lynx/LynxTemplateProvider.h>
 #import <Lynx/LynxView.h>
 #import <Lynx/LynxDebugger.h>
+#import <Lynx/LynxModule.h>

--- a/apple/HelloWorld/SceneDelegate.swift
+++ b/apple/HelloWorld/SceneDelegate.swift
@@ -9,7 +9,6 @@ class SceneDelegate: UIResponder, UIWindowSceneDelegate {
     window = UIWindow(windowScene: windowScene)
     
     let lynxView = LynxView { builder in
-      builder.config = LynxConfig(provider: TemplateProvider())
 #if DEBUG
       builder.enableGenericResourceFetcher = .true
       builder.genericResourceFetcher = GenericResourceFetcher()


### PR DESCRIPTION
This PR changes to use local config so users have a way to easily register modules (until we have proper auto linking). 